### PR TITLE
Begin Adding Support For Windows Modules

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,25 @@
+var __importStar = (this && this.__importStar) || function (mod) {
+  if (mod && mod.__esModule) return mod;
+  var result = {};
+  if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+  result["default"] = mod;
+  return result;
+};
+
+const exec = __importStar(require('@actions/exec'));
+const IS_WINDOWS = process.platform === 'win32';
+
+module.exports = {
+  wrappedExec: async function (commandString) {
+    let powerShellPreamble = 'powershell -noprofile -noninteractive -executionpolicy bypass -command '
+    if(IS_WINDOWS) {
+      commandString = powerShellPreamble += commandString
+    }
+  
+    await exec.exec(commandString)
+  },
+
+  IS_WINDOWS: IS_WINDOWS,
+
+  __importStar: __importStar
+};

--- a/modules/litmus_parallel/litmus_parallel.js
+++ b/modules/litmus_parallel/litmus_parallel.js
@@ -1,16 +1,11 @@
 "use strict";
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
+var path = require('path');
+var utilPath = path.join(__dirname,'..','..','lib','util.js');
+const util = require(utilPath);
 
 Object.defineProperty(exports, "__esModule", { value: true });
-const core = __importStar(require("@actions/core"));
-const exec = __importStar(require('@actions/exec'));
-const io = __importStar(require('@actions/io'));
+const core = util.__importStar(require("@actions/core"));
+
 async function run() {
   try {
       let platform = core.getInput('platform');
@@ -20,21 +15,21 @@ async function run() {
       core.exportVariable('PUPPET_GEM_VERSION', core.getInput('puppet_gem_version'));
 
       console.log(`=== Install bundle ===`);
-      await exec.exec('gem --version');
-      await exec.exec('gem install bundler');
-      await exec.exec('bundler -v');
-      await exec.exec(`bundle install --jobs 4 --retry 2 ${bundler_args}`);
+      await util.wrappedExec('gem --version');
+      await util.wrappedExec('gem install bundler');
+      await util.wrappedExec('bundler -v');
+      await util.wrappedExec(`bundle install --jobs 4 --retry 2 ${bundler_args}`);
 
       console.log(`=== Provision ===`);
-      await exec.exec(`bundle exec rake litmus:provision_list[${platform}]`);
+      await util.wrappedExec(`bundle exec rake litmus:provision_list[${platform}]`);
       if (platform.match(/_deb/)) {
-        await exec.exec('bundle exec bolt command run "apt-get update && apt-get install wget --yes" --inventoryfile inventory.yaml --nodes ssh_nodes');
+        await util.wrappedExec('bundle exec bolt command run "apt-get update && apt-get install wget --yes" --inventoryfile inventory.yaml --nodes ssh_nodes');
       }
-      await exec.exec(`bundle exec rake litmus:install_agent[${agent_family}]`);
-      await exec.exec('bundle exec rake litmus:install_module');
+      await util.wrappedExec(`bundle exec rake litmus:install_agent[${agent_family}]`);
+      await util.wrappedExec('bundle exec rake litmus:install_module');
 
       console.log(`=== Run Acceptance Tests ===`);
-      await exec.exec(`bundle exec rake litmus:acceptance:parallel`);
+      await util.wrappedExec(`bundle exec rake litmus:acceptance:parallel`);
   }
   catch (error) {
       core.setFailed(error.message);

--- a/modules/litmus_spec/litmus_spec.js
+++ b/modules/litmus_spec/litmus_spec.js
@@ -1,16 +1,11 @@
 "use strict";
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
+
+var path = require('path');
+var utilPath = path.join(__dirname,'..','..','lib','util.js');
+const util = require(utilPath);
 
 Object.defineProperty(exports, "__esModule", { value: true });
-const core = __importStar(require("@actions/core"));
-const exec = __importStar(require('@actions/exec'));
-const io = __importStar(require('@actions/io'));
+const core = util.__importStar(require("@actions/core"));
 async function run() {
   try {
       let bundler_args = core.getInput('bundler_args');
@@ -19,13 +14,17 @@ async function run() {
       core.exportVariable('PUPPET_GEM_VERSION', core.getInput('puppet_gem_version'));
 
       console.log(`=== Install bundle ===`);
-      await exec.exec('gem --version');
-      await exec.exec('gem install bundler');
-      await exec.exec('bundler -v');
-      await exec.exec(`bundle install --jobs 4 --retry 2 ${bundler_args}`);
+      if(util.IS_WINDOWS){
+        await util.wrappedExec('git config --system core.longpaths true');
+      }
+      await util.wrappedExec('gem --version');
+      await util.wrappedExec('gem install bundler');
+      await util.wrappedExec('bundle -v');
+      await util.wrappedExec(`bundle install --jobs 4 --retry 2 ${bundler_args}`);
 
       console.log(`=== Run Spec Tests ===`);
-      await exec.exec(`bundle exec rake ${check}`);
+      await util.wrappedExec('bundle exec rake spec_prep');
+      await util.wrappedExec(`bundle exec rake ${check}`);
   }
   catch (error) {
       core.setFailed(error.message);


### PR DESCRIPTION
Refactor utility functions into a utils file that other actions can
import to make it easier to make things run cross platform.

Start adding logic to the published tasks that account for Windows
modules running on Windows Server runners.