### PR TITLE
(IAC-544) Add teardown to workflow

### DIFF
--- a/lib/litmus_parallel.js
+++ b/lib/litmus_parallel.js
@@ -12,6 +12,7 @@ async function run() {
       let additional_command = core.getInput('additional_command');
 
       core.exportVariable('PUPPET_GEM_VERSION', core.getInput('puppet_gem_version'));
+      core.exportVariable('CI', true);
 
       console.log(`=== Install bundle ===`);
       await util.wrappedExec('gem --version');
@@ -33,6 +34,9 @@ async function run() {
 
       console.log(`=== Run Acceptance Tests ===`);
       await util.wrappedExec(`bundle exec rake litmus:acceptance:parallel`);
+
+      console.log(`=== Tear Down ===`);
+      await util.wrappedExec(`bundle exec rake litmus:tear_down`);
   }
   catch (error) {
       core.setFailed(error.message);


### PR DESCRIPTION
Following changes are done with this PR
exported the CI variable to avoid issues with the spinners in parallel acceptance output.
Add commands to tear-down the machines after the test case execution.